### PR TITLE
Improve month navigation performance

### DIFF
--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { getLatestPopularGames } from "@/src/lib/api";
+import { format } from "date-fns";
+
+export const revalidate = 86400; // Cache for 24 hours
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const month = searchParams.get("month") || format(new Date(), "yyyy-MM");
+
+  try {
+    const games = await getLatestPopularGames(month);
+    return NextResponse.json(games);
+  } catch (error) {
+    console.error("Error fetching games:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch games" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/GameList.tsx
+++ b/src/components/GameList.tsx
@@ -6,6 +6,7 @@ import { GameCard } from "@/src/components/GameCard";
 import { MonthSelector } from "@/src/components/MonthSelector";
 import { SortSelect } from "@/src/components/ui/sort-select";
 import { Game } from "@/src/lib/api";
+import { useGameData } from "@/src/hooks/useGameData";
 import { format } from "date-fns";
 
 interface GameListProps {
@@ -18,15 +19,17 @@ export function GameList({
   currentMonth = format(new Date(), "yyyy-MM"),
 }: GameListProps) {
   const router = useRouter();
-
-  const [activeMonth, setActiveMonth] = useState(currentMonth);
+  const { games, changeMonth, currentMonth: activeMonth } = useGameData(
+    initialGames,
+    currentMonth
+  );
   const [sortBy, setSortBy] = useState<"release_date" | "popularity">(
     "release_date"
   );
   const [isPending, startTransition] = useTransition();
 
   const sortedGames = useMemo(() => {
-    return [...initialGames].sort((a, b) => {
+    return [...games].sort((a, b) => {
       if (sortBy === "release_date") {
         // Sort oldest to newest
         return new Date(a.released).getTime() - new Date(b.released).getTime();
@@ -35,11 +38,11 @@ export function GameList({
         return b.added - a.added;
       }
     });
-  }, [initialGames, sortBy]);
+  }, [games, sortBy]);
 
   const handleMonthChange = (newMonth: string) => {
     startTransition(() => {
-      setActiveMonth(newMonth);
+      changeMonth(newMonth);
       router.push(`/?month=${newMonth}`, { scroll: false });
     });
   };

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from "react";
-import { getLatestPopularGames, Game } from "@/src/lib/api";
+import { Game } from "@/src/lib/api";
 import { format, addMonths, subMonths } from "date-fns";
 
 export function useGameData(initialGames: Game[], initialMonth: string) {
@@ -10,9 +10,17 @@ export function useGameData(initialGames: Game[], initialMonth: string) {
 
   const fetchGamesForMonth = useCallback(
     async (month: string) => {
-      if (!gameCache[month]) {
-        const games = await getLatestPopularGames(month);
+      if (gameCache[month]) return;
+
+      try {
+        const res = await fetch(`/api/games?month=${month}`);
+        if (!res.ok) {
+          throw new Error("Failed to fetch games for month " + month);
+        }
+        const games: Game[] = await res.json();
         setGameCache((prev) => ({ ...prev, [month]: games }));
+      } catch (err) {
+        console.error(err);
       }
     },
     [gameCache]


### PR DESCRIPTION
## Summary
- cache monthly game lists in a new API route
- use `useGameData` on the client to load months and preload adjacent months

## Testing
- `npx --yes next lint` *(fails: It looks like you're trying to use TypeScript but do not have the required packages installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b33ff9f9c832bb3fc17510d7bb746