### PR TITLE
Improve game card visuals and add store links

### DIFF
--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -64,7 +64,7 @@ export function GameCard({ game }: { game: Game }) {
   return (
     <>
       <Card
-        className="overflow-hidden relative group cursor-pointer transition-transform duration-200 hover:scale-105"
+        className="overflow-hidden relative group cursor-pointer transition-transform duration-200 hover:scale-105 rounded-lg shadow-md hover:shadow-lg"
         onClick={handleCardClick}
       >
         <div className="aspect-video relative">
@@ -98,7 +98,7 @@ export function GameCard({ game }: { game: Game }) {
               <span className="text-gray-500">No image available</span>
             </div>
           )}
-          <div className="absolute inset-0 bg-gradient-to-t from-black to-transparent opacity-70 transition-opacity group-hover:opacity-50" />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent transition-opacity group-hover:opacity-70" />
         </div>
         <CardContent className="absolute bottom-0 left-0 p-4 w-full">
           <h3 className="text-white text-xl font-bold mb-1 line-clamp-2">
@@ -112,6 +112,26 @@ export function GameCard({ game }: { game: Game }) {
               Metacritic: {game.metacritic}
             </p>
           )}
+          <div className="mt-2 flex space-x-3">
+            <a
+              href={`https://store.steampowered.com/search/?term=${encodeURIComponent(game.name)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-white text-xs underline hover:text-blue-300"
+              onClick={(e) => e.stopPropagation()}
+            >
+              Steam
+            </a>
+            <a
+              href={`https://gg.deals/search/?q=${encodeURIComponent(game.name)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-white text-xs underline hover:text-blue-300"
+              onClick={(e) => e.stopPropagation()}
+            >
+              GG.deals
+            </a>
+          </div>
           {error && <p className="text-red-500 text-sm mt-1">{error}</p>}
         </CardContent>
       </Card>

--- a/src/components/GameModal.tsx
+++ b/src/components/GameModal.tsx
@@ -163,6 +163,25 @@ export default function GameModal({
               </a>
             </div>
           )}
+          {gameDetails.stores?.length > 0 && (
+            <div className="mb-4">
+              <h3 className="font-semibold mb-1 text-gray-900">Where to Buy:</h3>
+              <ul className="list-disc pl-5 space-y-1">
+                {gameDetails.stores.map((store) => (
+                  <li key={store.id}>
+                    <a
+                      href={store.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:underline"
+                    >
+                      {store.name}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- enhance styling of `GameCard`
- add links to Steam and GG.deals from every game card
- display store links in the game detail modal

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b34561900832bb1a807964e25614b