### PR TITLE
Fix Month Selector Range

### DIFF
--- a/src/components/MonthSelector.tsx
+++ b/src/components/MonthSelector.tsx
@@ -43,10 +43,9 @@ export function MonthSelector({
   }, [selectedDate, handleMonthChange]);
 
   const monthOptions = useMemo(() => {
-    return Array.from({ length: 13 }, (_, i) => {
-      return subMonths(new Date(), i);
-    });
-  }, []);
+    const start = subMonths(selectedDate, 6);
+    return Array.from({ length: 13 }, (_, i) => addMonths(start, i));
+  }, [selectedDate]);
 
   return (
     <div className="flex items-center space-x-4 text-black">


### PR DESCRIPTION
## Summary
- center the month selector on the currently selected month

## Testing
- `npm run lint`
- `npm run build` *(fails: fetch failed during warmup)*

------
https://chatgpt.com/codex/tasks/task_e_684b350d752c832b96ebde9f6dde999e